### PR TITLE
Add privacy policy page, SEO updates, and refreshed styling

### DIFF
--- a/src/app/events/thomastag-2025/page.tsx
+++ b/src/app/events/thomastag-2025/page.tsx
@@ -1,9 +1,27 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Thomastag 2025 – Southern German Traditions Weekend',
   description:
     'Join Academic Culture Enjoyers in Nürnberg, 19–21 December 2025, for a weekend of student traditions and holiday spirit.',
+  keywords: [
+    'Thomastag',
+    'Nürnberg',
+    'student traditions',
+    'academic culture',
+    'kommers',
+    'event',
+  ],
+  alternates: { canonical: '/events/thomastag-2025' },
+  openGraph: {
+    title: 'Thomastag 2025 – Southern German Traditions Weekend',
+    description:
+      'Join Academic Culture Enjoyers in Nürnberg, 19–21 December 2025, for a weekend of student traditions and holiday spirit.',
+    url: 'https://academiccultureenjoyers.org/events/thomastag-2025',
+    siteName: 'Academic Culture Enjoyers',
+    type: 'event',
+  },
 };
 
 export default function Thomastag2025Page() {
@@ -155,6 +173,14 @@ export default function Thomastag2025Page() {
         </a>
         <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
           Seats are limited to 30 — first come, first served.
+        </p>
+        <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+          We only use your info for organizing events, share it only when
+          necessary (e.g. hostel bookings), and delete it after.{' '}
+          <Link href="/privacy" className="underline">
+            Full privacy notice
+          </Link>
+          .
         </p>
       </section>
     </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,19 +1,16 @@
 @import 'tailwindcss';
 
 :root {
-  --background: #ffffff;
   --foreground: #171717;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
     --foreground: #ededed;
   }
 }
 
 body {
-  background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     'kommers',
     'fraternities',
     'events',
+    'scholarly community',
+    'research tools',
+    'study tips',
   ],
   openGraph: {
     title: 'Academic Culture Enjoyers',
@@ -47,12 +50,6 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
-  keywords: [
-    'academic culture',
-    'scholarly community',
-    'research tools',
-    'study tips',
-  ],
 };
 
 export default function RootLayout({
@@ -62,7 +59,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">{children}</body>
+      <body className="flex min-h-screen flex-col bg-gradient-to-b from-white to-blue-50 antialiased dark:from-gray-900 dark:to-gray-950">
+        <main className="flex-1">{children}</main>
+        <footer className="border-t bg-white/60 p-4 text-center text-sm text-gray-600 backdrop-blur dark:bg-gray-900/60 dark:text-gray-400">
+          <a href="/privacy" className="hover:underline">
+            Privacy Policy
+          </a>
+        </footer>
+      </body>
     </html>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description: 'How Academic Culture Enjoyers handle your sign-up information.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="mb-6 text-3xl font-bold">
+        Privacy Policy – Academic Culture Enjoyers Sign-ups
+      </h1>
+      <p className="mb-8 text-gray-700 dark:text-gray-300">
+        We value your privacy and handle your information responsibly.
+      </p>
+      <section className="mb-6">
+        <h2 className="mb-2 text-2xl font-semibold">1. What we collect</h2>
+        <p className="mb-2 text-gray-700 dark:text-gray-300">
+          When you sign up for an event, we may ask for:
+        </p>
+        <ul className="list-disc pl-6 text-gray-700 dark:text-gray-300">
+          <li>Contact details (name, email, phone)</li>
+          <li>Travel/accommodation preferences</li>
+          <li>Dietary and accessibility needs</li>
+          <li>Emergency contact details</li>
+          <li>Other information relevant to the specific event</li>
+        </ul>
+      </section>
+      <section className="mb-6">
+        <h2 className="mb-2 text-2xl font-semibold">2. Why we collect it</h2>
+        <p className="text-gray-700 dark:text-gray-300">
+          We use this information only to:
+        </p>
+        <ul className="mt-2 list-disc pl-6 text-gray-700 dark:text-gray-300">
+          <li>
+            Organize event logistics (travel, accommodation, meals, activities)
+          </li>
+          <li>Communicate with you before and during the event</li>
+          <li>Ensure safety and accessibility</li>
+        </ul>
+      </section>
+      <section className="mb-6">
+        <h2 className="mb-2 text-2xl font-semibold">3. Who has access</h2>
+        <p className="text-gray-700 dark:text-gray-300">
+          Only designated event organizers have access to your information. We
+          may share minimal details with trusted partners (e.g. hostels,
+          restaurants, transport providers) when required for the event.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="mb-2 text-2xl font-semibold">4. How long we keep it</h2>
+        <p className="text-gray-700 dark:text-gray-300">
+          Your information is deleted no later than 4 weeks after the event
+          ends, unless required longer for accounting or legal reasons.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="mb-2 text-2xl font-semibold">5. Your rights</h2>
+        <p className="text-gray-700 dark:text-gray-300">
+          You can request access, correction, or deletion of your data at any
+          time. To do so, contact the organizers via the provided event contact
+          address.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="mb-2 text-2xl font-semibold">6. Legal basis</h2>
+        <p className="text-gray-700 dark:text-gray-300">
+          Your consent when signing up and our legitimate interest in safely and
+          effectively organizing events.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Introduce site-wide privacy policy page and footer link
- Refresh layout with gradient background and global footer
- Enhance Thomastag event page with SEO metadata and privacy notice

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0cafa54a88322b1600a09153deed3