### PR TITLE
Integrate Tally forms for membership and event sign-ups

### DIFF
--- a/src/app/events/thomastag-2025/page.tsx
+++ b/src/app/events/thomastag-2025/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import TallyForm from '@/components/TallyForm';
+import { createEventSignupForm } from '@/lib/tally';
 
 export const metadata: Metadata = {
   title: 'Thomastag 2025 – Southern German Traditions Weekend',
@@ -162,26 +164,37 @@ export default function Thomastag2025Page() {
         </p>
       </section>
 
-      <section className="text-center">
-        <h2 className="mb-4 text-2xl font-semibold">Ready to join?</h2>
+      <SignupSection />
+    </main>
+  );
+}
+
+async function SignupSection() {
+  const formId = await createEventSignupForm('Thomastag 2025');
+  return (
+    <section className="text-center">
+      <h2 className="mb-4 text-2xl font-semibold">Ready to join?</h2>
+      {formId ? (
+        <TallyForm formId={formId} height={600} />
+      ) : (
         <a
           href="https://example.com/signup"
           className="rounded bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-500"
         >
           Sign up here
         </a>
-        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-          Seats are limited to 30 — first come, first served.
-        </p>
-        <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
-          We only use your info for organizing events, share it only when
-          necessary (e.g. hostel bookings), and delete it after.{' '}
-          <Link href="/privacy" className="underline">
-            Full privacy notice
-          </Link>
-          .
-        </p>
-      </section>
-    </main>
+      )}
+      <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        Seats are limited to 30 — first come, first served.
+      </p>
+      <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+        We only use your info for organizing events, share it only when
+        necessary (e.g. hostel bookings), and delete it after.{' '}
+        <Link href="/privacy" className="underline">
+          Full privacy notice
+        </Link>
+        .
+      </p>
+    </section>
   );
 }

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import TallyForm from '@/components/TallyForm';
+import { createMembershipForm } from '@/lib/tally';
+
+export const metadata: Metadata = {
+  title: 'Join',
+  description: 'Apply for membership in Academic Culture Enjoyers.',
+  keywords: ['membership', 'join', 'application'],
+};
+
+export default async function JoinPage() {
+  const formId = await createMembershipForm();
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="mb-4 text-3xl font-bold">Join Academic Culture Enjoyers</h1>
+      <p className="mb-6 text-gray-700 dark:text-gray-300">
+        Fill out the form below to apply for membership.
+      </p>
+      {formId ? (
+        <TallyForm formId={formId} />
+      ) : (
+        <p className="text-gray-700 dark:text-gray-300">
+          Membership form unavailable. Please try again later.
+        </p>
+      )}
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,6 +60,9 @@ export default function Home() {
             Connect with fellow enjoyers and share your passion for knowledge
             and tradition.
           </p>
+          <Link href="/join" className="text-blue-600 hover:underline">
+            Apply for membership
+          </Link>
         </section>
         <section className="mt-10">
           <h2 className="mb-2 text-2xl font-semibold">Upcoming Event</h2>

--- a/src/components/TallyForm.tsx
+++ b/src/components/TallyForm.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function TallyForm({
+  formId,
+  height = 800,
+}: {
+  formId: string;
+  height?: number;
+}) {
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://tally.so/widgets/embed.js';
+    script.async = true;
+    document.body.appendChild(script);
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <iframe
+      data-tally-src={`https://tally.so/r/${formId}?transparentBackground=1&hideTitle=1`}
+      width="100%"
+      height={height}
+      frameBorder="0"
+      marginHeight={0}
+      marginWidth={0}
+      title="Tally form"
+    />
+  );
+}

--- a/src/lib/tally.ts
+++ b/src/lib/tally.ts
@@ -1,0 +1,95 @@
+const API_BASE = 'https://api.tally.so/v1';
+
+async function request<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T | null> {
+  const token = process.env.TALLY_API;
+  if (!token) return null;
+
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    console.error('Tally API error', res.status);
+    return null;
+  }
+
+  return (res.json() as Promise<T>);
+}
+
+interface TallyFormSummary {
+  id: string;
+  title: string;
+}
+
+interface TallyFormsResponse {
+  data?: TallyFormSummary[];
+}
+
+interface TallyCreateResponse {
+  id?: string;
+  data?: { id: string };
+}
+
+export async function createMembershipForm() {
+  const list = await request<TallyFormsResponse>('/forms');
+  const existing = list?.data?.find((f) => f.title === 'Membership Application');
+  if (existing) return existing.id;
+
+  const created = await request<TallyCreateResponse>('/forms', {
+    method: 'POST',
+    body: JSON.stringify({
+      title: 'Membership Application',
+      fields: [
+        {
+          type: 'short_text',
+          title: 'Full Name',
+          properties: { required: true },
+        },
+        {
+          type: 'email',
+          title: 'Email',
+          properties: { required: true },
+        },
+      ],
+    }),
+  });
+
+  return created?.data?.id || created?.id || '';
+}
+
+export async function createEventSignupForm(event: string) {
+  const title = `${event} Signup`;
+  const list = await request<TallyFormsResponse>('/forms');
+  const existing = list?.data?.find((f) => f.title === title);
+  if (existing) return existing.id;
+
+  const created = await request<TallyCreateResponse>('/forms', {
+    method: 'POST',
+    body: JSON.stringify({
+      title,
+      fields: [
+        {
+          type: 'short_text',
+          title: 'Full Name',
+          properties: { required: true },
+        },
+        {
+          type: 'email',
+          title: 'Email',
+          properties: { required: true },
+        },
+      ],
+    }),
+  });
+
+  return created?.data?.id || created?.id || '';
+}


### PR DESCRIPTION
## Summary
- embed Tally-powered membership application page
- add reusable TallyForm component and API utilities
- replace Thomastag 2025 sign-up link with Tally form and link to join page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ceccfbe8832298f9b4fd8f629eb6