### PR TITLE
Use Tally for event signup form

### DIFF
--- a/scripts/createForms.js
+++ b/scripts/createForms.js
@@ -1,4 +1,4 @@
-const API_BASE = 'https://api.tally.so/v1';
+const API_BASE = 'https://api.tally.so/';
 
 async function request(path, options = {}) {
   const token = process.env.TALLY_API;
@@ -6,7 +6,7 @@ async function request(path, options = {}) {
     throw new Error('TALLY_API not set');
   }
 
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(`${API_BASE}v1${path}`, {
     ...options,
     headers: {
       Authorization: `Bearer ${token}`,
@@ -30,7 +30,7 @@ async function ensureForm(title, fields) {
 
   const created = await request('/forms', {
     method: 'POST',
-    body: JSON.stringify({ title, fields }),
+    body: JSON.stringify({ title, fields, status: 'published' }),
   });
 
   return created?.data?.id || created?.id || '';

--- a/src/app/events/thomastag-2025/page.tsx
+++ b/src/app/events/thomastag-2025/page.tsx
@@ -177,12 +177,9 @@ async function SignupSection() {
       {formId ? (
         <TallyForm formId={formId} height={600} />
       ) : (
-        <a
-          href="https://example.com/signup"
-          className="rounded bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-500"
-        >
-          Sign up here
-        </a>
+        <p className="text-gray-700 dark:text-gray-300">
+          Signup form unavailable. Please try again later.
+        </p>
       )}
       <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
         Seats are limited to 30 — first come, first served.

--- a/src/lib/tally.ts
+++ b/src/lib/tally.ts
@@ -1,4 +1,4 @@
-const API_BASE = 'https://api.tally.so/v1';
+const API_BASE = 'https://api.tally.so/';
 
 async function request<T>(
   path: string,
@@ -7,7 +7,7 @@ async function request<T>(
   const token = process.env.TALLY_API;
   if (!token) return null;
 
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(`${API_BASE}v1${path}`, {
     ...options,
     headers: {
       Authorization: `Bearer ${token}`,
@@ -62,6 +62,7 @@ export async function createMembershipForm() {
           properties: { required: true },
         },
       ],
+      status: 'published',
     }),
   });
 
@@ -90,6 +91,7 @@ export async function createEventSignupForm(event: string) {
           properties: { required: true },
         },
       ],
+      status: 'published',
     }),
   });
 


### PR DESCRIPTION
## Summary
- Remove fallback external link and always use Tally for Thomastag 2025 signup
- Show message if Tally form unavailable instead of external signup link
- Include required `status` field when creating Tally forms
- Centralize Tally API base URL and append version in requests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`
- `npm run create-forms` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dc5bad108322af3fa3bb04105a2a