### PR TITLE
Use existing Tally forms instead of creating new ones

### DIFF
--- a/src/app/events/thomastag-2025/page.tsx
+++ b/src/app/events/thomastag-2025/page.tsx
@@ -1,5 +1,5 @@
 import TallyForm from '@/components/TallyForm';
-import { createEventSignupForm } from '@/lib/tally';
+import { getEventSignupForm } from '@/lib/tally';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
@@ -170,7 +170,7 @@ export default function Thomastag2025Page() {
 }
 
 async function SignupSection() {
-  const formId = await createEventSignupForm('Thomastag 2025');
+  const formId = await getEventSignupForm('Thomastag 2025');
   return (
     <section className="text-center">
       <h2 className="mb-4 text-2xl font-semibold">Ready to join?</h2>

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,5 +1,5 @@
 import TallyForm from '@/components/TallyForm';
-import { createMembershipForm } from '@/lib/tally';
+import { getMembershipForm } from '@/lib/tally';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 };
 
 export default async function JoinPage() {
-  const formId = await createMembershipForm();
+  const formId = await getMembershipForm();
 
   return (
     <main className="mx-auto max-w-3xl p-8">

--- a/src/lib/tally.ts
+++ b/src/lib/tally.ts
@@ -1,4 +1,4 @@
-const API_BASE = 'https://api.tally.so/';
+const API_BASE = 'https://api.tally.so';
 
 async function request<T>(
   path: string,
@@ -26,73 +26,23 @@ async function request<T>(
 
 interface TallyFormSummary {
   id: string;
-  title: string;
+  name: string;
 }
 
 interface TallyFormsResponse {
-  data?: TallyFormSummary[];
+  items?: TallyFormSummary[];
 }
 
-interface TallyCreateResponse {
-  id?: string;
-  data?: { id: string };
-}
-
-export async function createMembershipForm() {
+async function findFormIdByName(name: string) {
   const list = await request<TallyFormsResponse>('/forms');
-  const existing = list?.data?.find(
-    (f) => f.title === 'Membership Application',
-  );
-  if (existing) return existing.id;
-
-  const created = await request<TallyCreateResponse>('/forms', {
-    method: 'POST',
-    body: JSON.stringify({
-      title: 'Membership Application',
-      fields: [
-        {
-          type: 'short_text',
-          title: 'Full Name',
-          properties: { required: true },
-        },
-        {
-          type: 'email',
-          title: 'Email',
-          properties: { required: true },
-        },
-      ],
-      status: 'published',
-    }),
-  });
-
-  return created?.data?.id || created?.id || '';
+  const existing = list?.items?.find((f) => f.name === name);
+  return existing?.id || '';
 }
 
-export async function createEventSignupForm(event: string) {
-  const title = `${event} Signup`;
-  const list = await request<TallyFormsResponse>('/forms');
-  const existing = list?.data?.find((f) => f.title === title);
-  if (existing) return existing.id;
+export async function getMembershipForm() {
+  return findFormIdByName('Membership Application');
+}
 
-  const created = await request<TallyCreateResponse>('/forms', {
-    method: 'POST',
-    body: JSON.stringify({
-      title,
-      fields: [
-        {
-          type: 'short_text',
-          title: 'Full Name',
-          properties: { required: true },
-        },
-        {
-          type: 'email',
-          title: 'Email',
-          properties: { required: true },
-        },
-      ],
-      status: 'published',
-    }),
-  });
-
-  return created?.data?.id || created?.id || '';
+export async function getEventSignupForm(event: string) {
+  return findFormIdByName(`${event} Signup`);
 }


### PR DESCRIPTION
## Summary
- Lookup Tally forms by name and return their IDs instead of creating new forms
- Update membership and event pages to use new `get*` helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb237f288322b0a7c7ef8071aa56