### PR TITLE
feat: improve navigation and SEO

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Events',
+  description: 'Explore upcoming events from Academic Culture Enjoyers.',
+};
+
+export default function EventsPage() {
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="mb-6 text-3xl font-bold">Events</h1>
+      <ul className="list-disc pl-6 text-gray-700 dark:text-gray-300">
+        <li>
+          <Link
+            href="/events/thomastag-2025"
+            className="text-blue-600 hover:underline"
+          >
+            Thomastag 2025 – Southern German Traditions Weekend
+          </Link>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import Header from '@/components/Header';
 import type { Metadata } from 'next';
 import './globals.css';
 
@@ -60,7 +61,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="flex min-h-screen flex-col bg-gradient-to-b from-white to-blue-50 antialiased dark:from-gray-900 dark:to-gray-950">
-        <main className="flex-1">{children}</main>
+        <Header />
+        <main id="content" className="flex-1">
+          {children}
+        </main>
         <footer className="border-t bg-white/60 p-4 text-center text-sm text-gray-600 backdrop-blur dark:bg-gray-900/60 dark:text-gray-400">
           <a href="/privacy" className="hover:underline">
             Privacy Policy

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,7 +51,11 @@ export default function Home() {
           <h2 className="mb-2 text-2xl font-semibold">Events & Trips</h2>
           <p className="text-gray-700 dark:text-gray-300">
             Join visits to student fraternities, sitsits, and other academic
-            festivities around the world.
+            festivities around the world.{' '}
+            <Link href="/events" className="text-blue-600 hover:underline">
+              See upcoming events
+            </Link>
+            .
           </p>
         </section>
         <section>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: '*', allow: '/' }],
+    sitemap: 'https://academiccultureenjoyers.org/sitemap.xml',
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://academiccultureenjoyers.org';
+  const routes = [
+    '',
+    '/events',
+    '/events/thomastag-2025',
+    '/join',
+    '/privacy',
+  ].map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+  }));
+
+  return routes;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const navLinks = [
+  { href: '/', label: 'Home' },
+  { href: '/events', label: 'Events' },
+  { href: '/join', label: 'Join' },
+];
+
+export default function Header() {
+  const pathname = usePathname();
+
+  return (
+    <header className="border-b bg-white/60 text-gray-700 backdrop-blur dark:bg-gray-900/60 dark:text-gray-300">
+      <a href="#content" className="sr-only focus:not-sr-only">
+        Skip to main content
+      </a>
+      <nav className="mx-auto flex max-w-4xl gap-4 p-4">
+        {navLinks.map(({ href, label }) => {
+          const isActive = pathname === href || pathname.startsWith(`${href}/`);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`hover:underline ${isActive ? 'font-semibold' : ''}`}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+    </header>
+  );
+}

--- a/src/components/TallyForm.tsx
+++ b/src/components/TallyForm.tsx
@@ -28,6 +28,8 @@ export default function TallyForm({
       marginHeight={0}
       marginWidth={0}
       title="Tally form"
+      loading="lazy"
+      referrerPolicy="no-referrer-when-downgrade"
     />
   );
 }


### PR DESCRIPTION
## Summary
- add global header with skip link and navigation
- surface sitemap and robots metadata for search engines
- list upcoming events and link from home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a16b82ff6c8322abfa36017b44c92e