### PR TITLE
refactor: custom theme toggle and ui polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@typescript-eslint/eslint-plugin": "8.39.1",
         "@typescript-eslint/parser": "8.39.1",
         "clsx": "2.1.1",
-        "dotenv": "^17.2.1",
         "eslint": "9.33.0",
         "eslint-config-next": "15.4.6",
         "eslint-config-prettier": "10.1.8",
@@ -3028,19 +3027,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -10,16 +10,19 @@ export default function EventsPage() {
   return (
     <main className="mx-auto max-w-3xl p-8">
       <h1 className="mb-6 text-3xl font-bold">Events</h1>
-      <ul className="list-disc pl-6 text-gray-700 dark:text-gray-300">
-        <li>
-          <Link
-            href="/events/thomastag-2025"
-            className="text-blue-600 hover:underline"
-          >
+      <div className="grid gap-4">
+        <Link
+          href="/events/thomastag-2025"
+          className="block rounded-lg border p-4 shadow-sm transition hover:border-blue-500 hover:shadow-md focus:outline-none focus-visible:ring"
+        >
+          <h2 className="mb-1 text-xl font-semibold">
             Thomastag 2025 – Southern German Traditions Weekend
-          </Link>
-        </li>
-      </ul>
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            19–21 December 2025 · Nürnberg, Germany
+          </p>
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Header from '@/components/Header';
+import Providers from '@/components/Providers';
 import type { Metadata } from 'next';
 import './globals.css';
 
@@ -60,16 +61,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="flex min-h-screen flex-col bg-gradient-to-b from-white to-blue-50 antialiased dark:from-gray-900 dark:to-gray-950">
-        <Header />
-        <main id="content" className="flex-1">
-          {children}
-        </main>
-        <footer className="border-t bg-white/60 p-4 text-center text-sm text-gray-600 backdrop-blur dark:bg-gray-900/60 dark:text-gray-400">
-          <a href="/privacy" className="hover:underline">
-            Privacy Policy
-          </a>
-        </footer>
+      <body className="flex min-h-screen flex-col bg-gradient-to-b from-white to-blue-50 antialiased transition-colors duration-300 dark:from-gray-900 dark:to-gray-950">
+        <Providers>
+          <Header />
+          <main id="content" className="flex-1">
+            {children}
+          </main>
+          <footer className="border-t bg-white/60 p-4 text-center text-sm text-gray-600 backdrop-blur dark:bg-gray-900/60 dark:text-gray-400">
+            <a href="/privacy" className="hover:underline">
+              Privacy Policy
+            </a>
+          </footer>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,10 @@ export default function Home() {
           <p className="text-gray-700 dark:text-gray-300">
             Join visits to student fraternities, sitsits, and other academic
             festivities around the world.{' '}
-            <Link href="/events" className="text-blue-600 hover:underline">
+            <Link
+              href="/events"
+              className="inline-block rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none focus-visible:ring"
+            >
               See upcoming events
             </Link>
             .
@@ -64,7 +67,10 @@ export default function Home() {
             Connect with fellow enjoyers and share your passion for knowledge
             and tradition.
           </p>
-          <Link href="/join" className="text-blue-600 hover:underline">
+          <Link
+            href="/join"
+            className="mt-2 inline-block rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none focus-visible:ring"
+          >
             Apply for membership
           </Link>
         </section>
@@ -75,7 +81,7 @@ export default function Home() {
           </p>
           <Link
             href="/events/thomastag-2025"
-            className="text-blue-600 hover:underline"
+            className="inline-block rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none focus-visible:ring"
           >
             Learn more and sign up
           </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import ThemeToggle from './ThemeToggle';
 
 const navLinks = [
   { href: '/', label: 'Home' },
@@ -13,24 +14,27 @@ export default function Header() {
   const pathname = usePathname();
 
   return (
-    <header className="border-b bg-white/60 text-gray-700 backdrop-blur dark:bg-gray-900/60 dark:text-gray-300">
+    <header className="sticky top-0 z-50 border-b bg-white/60 text-gray-700 backdrop-blur shadow-sm dark:bg-gray-900/60 dark:text-gray-300">
       <a href="#content" className="sr-only focus:not-sr-only">
         Skip to main content
       </a>
-      <nav className="mx-auto flex max-w-4xl gap-4 p-4">
-        {navLinks.map(({ href, label }) => {
-          const isActive = pathname === href || pathname.startsWith(`${href}/`);
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={`hover:underline ${isActive ? 'font-semibold' : ''}`}
-              aria-current={isActive ? 'page' : undefined}
-            >
-              {label}
-            </Link>
-          );
-        })}
+      <nav className="mx-auto flex max-w-4xl items-center justify-between p-4">
+        <div className="flex gap-4">
+          {navLinks.map(({ href, label }) => {
+            const isActive = pathname === href || pathname.startsWith(`${href}/`);
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`rounded px-2 py-1 transition-colors hover:bg-gray-100 hover:no-underline dark:hover:bg-gray-800 ${isActive ? 'font-semibold bg-gray-100 dark:bg-gray-800' : ''}`}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </div>
+        <ThemeToggle />
       </nav>
     </header>
   );

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return ctx;
+}
+
+export default function Providers({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored ?? (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+    document.documentElement.classList.toggle('dark', initial === 'dark');
+  }, []);
+
+  const toggleTheme = () => {
+    setTheme(prev => {
+      const next = prev === 'dark' ? 'light' : 'dark';
+      document.documentElement.classList.toggle('dark', next === 'dark');
+      localStorage.setItem('theme', next);
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useTheme } from './Providers';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle dark mode"
+      aria-pressed={theme === 'dark'}
+      className="rounded p-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+      >
+      {theme === 'dark' ? '🌙' : '☀️'}
+      </button>
+  );
+}


### PR DESCRIPTION
## Summary
- replace next-themes with custom context-based theme provider
- remove suppressHydrationWarning and smooth theme transitions
- polish header navigation and CTA focus states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1720744588322953cee37a3185a10