### PR TITLE
Fix dark mode handling for entire page

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -36,7 +36,17 @@ export default function Providers({ children }: { children: ReactNode }) {
   });
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
+    const root = document.documentElement;
+    const body = document.body;
+
+    if (theme === 'dark') {
+      root.classList.add('dark');
+      body.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+      body.classList.remove('dark');
+    }
+
     localStorage.setItem('theme', theme);
   }, [theme]);
 


### PR DESCRIPTION
## Summary
- ensure theme toggling adds or removes `dark` class on both `<html>` and `<body>` elements so backgrounds and other components switch correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a34ff120c08322a0fc7f2a4f3f15d9